### PR TITLE
corrected array name to match contents

### DIFF
--- a/Elements.xml
+++ b/Elements.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string-array name="Presidents">
+    <string-array name="Elements">
 		<item>
 			<name>Hydrogen</name>	
 			<symbol>H</symbol>	


### PR DESCRIPTION
It looks like the Elements array and the Presidents array were added at the same time. The Elements array was incorrectly labeled "Presidents". This PR corrects that.
